### PR TITLE
Make the module RedHat compatible

### DIFF
--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,0 +1,3 @@
+---
+certificate_checker::package_provider: "puppet_gem"
+certificate_checker::certificate_checker_path: "/opt/puppetlabs/puppet/bin/certificate-checker"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,3 @@
+---
+certificate_checker::package_provider: "gem"
+certificate_checker::certificate_checker_path: "/usr/local/bin/certificate-checker"

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+hierarchy:
+  - name: 'Operating System Family'
+    path: '%{facts.os.family}.yaml'
+  - name: 'common'
+    path: 'common.yaml'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,7 @@
 # @summary Configure certificate_checker
 #
+# @param package_provider
+# @param certificate_checker_path
 # @param logfile Logfile to store certificates status
 # @param ensure
 # @param hour
@@ -10,6 +12,9 @@
 # @param user User to check certificates status as
 # @param group Group to check certificates status as
 class certificate_checker (
+  Enum['gem', 'puppet_gem'] $package_provider,
+  String                    $certificate_checker_path,
+
   String $logfile = '/var/log/certificate-checker.jsonl',
   String $ensure = 'installed',
 
@@ -24,7 +29,7 @@ class certificate_checker (
 ) {
   package { 'certificate-checker':
     ensure   => $ensure,
-    provider => 'gem',
+    provider => $package_provider,
   }
 
   file { $logfile:
@@ -37,7 +42,7 @@ class certificate_checker (
   $args = certificate_checker::watched_paths().join(' ')
 
   cron { 'certificate-checker':
-    command  => "/usr/local/bin/certificate-checker -o ${logfile} ${args}",
+    command  => "${certificate_checker_path} -o ${logfile} ${args}",
 
     hour     => $hour,
     minute   => $minute,


### PR DESCRIPTION
EL7 ships with a legacy version of Ruby nobody wants to use.  But since
Puppet ships with [a recent version of] Ruby, use it!