### PR TITLE
Ignore nonexistent files

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,8 @@
+fixtures:
+  repositories:
+    cron_core:
+      repo: "https://github.com/puppetlabs/puppetlabs-cron_core"
+      puppet_version: '>= 6.0.0'
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
+  symlinks:
+    certificate_checker: "#{source_dir}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ Metrics/BlockLength:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+Style/TrailingCommaInArrayLiteral:
+  Description: Be consistent with Puppet's style
+  EnforcedStyleForMultiline: comma
 Style/TrailingCommaInHashLiteral:
   Description: Be consistent with Puppet's style
   EnforcedStyleForMultiline: comma

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class certificate_checker (
   String                    $certificate_checker_path,
 
   String $logfile = '/var/log/certificate-checker.jsonl',
-  String $ensure = 'installed',
+  String $ensure = '1.2.0',
 
   Any $hour = '*/4',
   Any $minute = fqdn_rand(60),
@@ -42,7 +42,7 @@ class certificate_checker (
   $args = certificate_checker::watched_paths().join(' ')
 
   cron { 'certificate-checker':
-    command  => "${certificate_checker_path} -o ${logfile} ${args}",
+    command  => "${certificate_checker_path} --output=${logfile} --ignore-nonexistent ${args}",
 
     hour     => $hour,
     minute   => $minute,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'certificate_checker' do
+  before(:each) do
+    Puppet::Parser::Functions.newfunction(:puppetdb_query, type: :rvalue) do |_args|
+      [
+        {
+          'parameters' => {
+            'paths' => [
+              '/a.pem',
+              '/b.pem',
+            ],
+          },
+        },
+        {
+          'parameters' => {
+            'paths' => [
+              '/b.pem',
+              '/c.pem',
+            ],
+          },
+        },
+      ]
+    end
+  end
+
+  it { is_expected.to compile }
+  it { is_expected.to contain_cron('certificate-checker').with(command: '/usr/local/bin/certificate-checker --output=/var/log/certificate-checker.jsonl /a.pem /b.pem /c.pem') }
+
+  context 'with ignore_nonexistent' do
+    let(:params) do
+      {
+        ignore_nonexistent: true,
+      }
+    end
+
+    it { is_expected.to contain_cron('certificate-checker').with(command: '/usr/local/bin/certificate-checker --output=/var/log/certificate-checker.jsonl --ignore-nonexistent /a.pem /b.pem /c.pem') }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+require 'rspec-puppet-facts'
+include RspecPuppetFacts # rubocop:disable Style/MixinUsage
+
+RSpec.configure do |c|
+  c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+end


### PR DESCRIPTION
If a certificate never existed, the warning has no value.  If the
certificate was removed, the last event will expire.