### PR TITLE
Use Ruby from AIO Puppet on Debian

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,0 +1,3 @@
+---
+certificate_checker::package_provider: "puppet_gem"
+certificate_checker::certificate_checker_path: "/opt/puppetlabs/puppet/bin/certificate-checker"


### PR DESCRIPTION
certificate-checker depends on third-party gems which require a more
recent version of Ruby than what Debian oldstable ships with.

Align with RedHat and when running on a platform where AIO Puppet is
available, default to use the version of Ruby shipped with AIO Puppet.
