### PR TITLE
Require Puppet 7+

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,0 +1,3 @@
+---
+certificate_checker::package_provider: "puppet_gem"
+certificate_checker::certificate_checker_path: "/opt/puppetlabs/puppet/bin/certificate-checker"

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
The version of Ruby bundled with Puppet 6 is too old to run
ceritficate-checker. When using AIO package, we need at least Puppet 7.

This PR also include:
* #23 